### PR TITLE
Bugfix

### DIFF
--- a/service/core/factory.py
+++ b/service/core/factory.py
@@ -1145,6 +1145,11 @@ def edited_message_handler(message):
                         bot.restrict_with_warning(message, detected_topics, user)
                         # we end process here by returning
                         return
+                # checking whether it's required to edit it if we had an old response
+                if existing_code.response_message_id and (existing_code.result != response.result) and (existing_code.errors != response.errors):
+                    same_result = False
+                else:
+                    same_result = True
                 formatted_response = interpreter.format_response(response)
                 existing_code.errors = response.errors
                 existing_code.result = response.result
@@ -1152,8 +1157,10 @@ def edited_message_handler(message):
                 if existing_code.response_message_id:
                     # we might have old response
                     try:
-                        bot.edit_message_text(chat_id=cid, message_id=existing_code.response_message_id,
-                                              text=formatted_response, parse_mode=constants.DEFAULT_PARSE_MODE)
+                        # just ignore it if the result is going to be the same
+                        if not same_result:
+                            bot.edit_message_text(chat_id=cid, message_id=existing_code.response_message_id,
+                                                 text=formatted_response, parse_mode=constants.DEFAULT_PARSE_MODE)
                     except telebot.apihelper.ApiTelegramException:
                         # could not edit, let's try sending new message
                         resp_msg = bot.reply_to(message, formatted_response,


### PR DESCRIPTION
**(Not tested)**
Possible fix to a bug, when a user edited their code but the bot sent a new message instead of editing the existent response. It's not the most optimal solution, because it's causing a little repetition by checking "existing_code.response_message_id" twice at lines 1149 and 1157.