### PR TITLE
fixing user notification on MAQ

### DIFF
--- a/greed_island/factory.py
+++ b/greed_island/factory.py
@@ -150,7 +150,8 @@ def text_handler(message):
                 question = QuestionRepository.register(
                     question_text, question_author, message.reply_to_message, tags, tag_author=user)
                 notifier = notifications.QuestionNotifier(question, urify, strings, bot)
-                notifier.notify_about_marking_as_question(tags, message)
+                # notify question author
+                notifier.notify_about_marking_as_question(tags, message.reply_to_message)
 
                 bot.delete_message(cid, message.message_id)
 


### PR DESCRIPTION
When admins of the chat marks a message as a question, the notification message is sent to the admin rather than the author of the question. 
I've changed this part that now the actual author of the message is notified.